### PR TITLE
Improve chat page layout

### DIFF
--- a/GameServer/Pages/Chat.cshtml
+++ b/GameServer/Pages/Chat.cshtml
@@ -3,11 +3,18 @@
 @{
     ViewData["Title"] = "Chat";
 }
-<div class="container">
-    <input class="form-control mb-2" id="userInput" placeholder="Name" />
-    <input class="form-control mb-2" id="messageInput" placeholder="Message" />
-    <button class="btn btn-primary" id="sendButton">Send</button>
-    <ul id="messagesList" class="list-unstyled mt-3"></ul>
+<div id="mobileChat" class="container d-flex flex-column" style="height:100vh;">
+    <div id="usernameForm" class="my-auto">
+        <input class="form-control mb-2" id="userInput" placeholder="Name" />
+        <button class="btn btn-primary" id="joinButton">Join</button>
+    </div>
+    <div id="chatArea" class="d-flex flex-column flex-grow-1" style="display:none;">
+        <ul id="messagesList" class="list-unstyled flex-grow-1 mb-2 overflow-auto"></ul>
+        <div class="input-group">
+            <input class="form-control" id="messageInput" placeholder="Message" />
+            <button class="btn btn-primary" id="sendButton">Send</button>
+        </div>
+    </div>
 </div>
 @section Scripts {
     <script src="~/lib/microsoft/signalr/dist/browser/signalr.min.js"></script>

--- a/GameServer/Pages/Index.cshtml
+++ b/GameServer/Pages/Index.cshtml
@@ -8,7 +8,7 @@
         <div>
             <div class="d-flex flex-column h-100" style="height: 100vh;">
                 <h2 class="mt-3">Chat Room</h2>
-                <div id="chatContainer" class="flex-grow-1 overflow-auto border rounded p-3 bg-light" style="min-height: 400px; max-height: 80vh;">
+                <div id="chatContainer" class="flex-grow-1 border rounded p-3 bg-light" style="overflow-y:auto; height:calc(100vh - 220px); padding-right:210px; padding-bottom:210px;">
                     <ul id="messagesList" class="list-unstyled mb-0"></ul>
                 </div>
             </div>

--- a/GameServer/wwwroot/css/site.css
+++ b/GameServer/wwwroot/css/site.css
@@ -20,3 +20,19 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+#chatContainer {
+  overflow-y: auto;
+  height: calc(100vh - 220px);
+  padding-right: 210px;
+  padding-bottom: 210px;
+}
+
+#mobileChat {
+  height: 100vh;
+}
+
+#mobileChat #messagesList {
+  overflow-y: auto;
+  flex-grow: 1;
+}

--- a/GameServer/wwwroot/js/mobile.js
+++ b/GameServer/wwwroot/js/mobile.js
@@ -2,6 +2,8 @@
 
 const connection = new signalR.HubConnectionBuilder().withUrl("/Game000/chatHub").build();
 
+let userName = "";
+
 document.getElementById("sendButton").disabled = true;
 
 connection.on("ReceiveMessage", function (user, message) {
@@ -12,15 +14,27 @@ connection.on("ReceiveMessage", function (user, message) {
 
 connection.start().then(function () {
     connection.invoke("JoinRoom", roomId);
-    document.getElementById("sendButton").disabled = false;
 }).catch(function (err) {
     return console.error(err.toString());
 });
 
+document.getElementById("joinButton").addEventListener("click", function (event) {
+    const nameInput = document.getElementById("userInput");
+    const name = nameInput.value.trim();
+    if (name !== "") {
+        userName = name;
+        document.getElementById("usernameForm").style.display = "none";
+        const chatArea = document.getElementById("chatArea");
+        chatArea.style.display = "flex";
+        document.getElementById("sendButton").disabled = false;
+        document.getElementById("messageInput").focus();
+    }
+    event.preventDefault();
+});
+
 document.getElementById("sendButton").addEventListener("click", function (event) {
-    const user = document.getElementById("userInput").value;
     const message = document.getElementById("messageInput").value;
-    connection.invoke("SendMessage", roomId, user, message).catch(function (err) {
+    connection.invoke("SendMessage", roomId, userName, message).catch(function (err) {
         return console.error(err.toString());
     });
     document.getElementById("messageInput").value = "";


### PR DESCRIPTION
## Summary
- ensure desktop chat area fills the page and leaves room for the QR code
- redesign mobile chat workflow with username entry and fixed message box
- adjust mobile JS logic to support the two–step chat join
- add related CSS tweaks

## Testing
- `dotnet build Game000.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445fa1d6908331927df329120d9860